### PR TITLE
Change image macos-13-xlarge to macos-14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
     build:
-        runs-on: macos-13-xlarge # pagefind not working on x64 architecture
+        runs-on: macos-14 # pagefind not working on x64 architecture
         steps:
         - uses: actions/checkout@v4
           with:


### PR DESCRIPTION
- [ActionsでM1 Macが無料で使えるように。DockerやGoの話も｜Productivity Weekly(2024-01-31号)](https://zenn.dev/cybozu_ept/articles/productivity-weekly-20240131)

> - `macos-11`: deprecated。2024/6 終了予定
> - `macos-13`, `macos-13-large`: Intel Mac（今回特に変更なし）
> - `macos-13-xlarge`: M1 Mac。beta が外れて GA に
> - `macos-14`: 今回追加。M1 Mac。public リポジトリ無料、beta
> - `macos-14-large`: 今回追加。[Intel Mac](https://x.com/miyajan/status/1757291617483157509?s=20)。有料のみ、beta
> - `macos-14-xlarge`: 今回追加。M1 Mac。有料のみ、beta
> - `macos-latest`, `macos-latest-large`: 今は macOS 12 系を指すが、2024/4-6 に macOS 14 系を指すように変更予定
> - `macos-latest-xlarge`: 今は macOS 13 を指すが、2024/4-6 に macOS 14 系を指すように変更予定（たぶん）