### PR TITLE
Potential fix for code scanning alert no. 1: Expression injection in Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,9 +50,11 @@ jobs:
 
     - name: Set Build parameter
       id: build-parameter
+      env:
+        HEAD_REF: ${{ github.head_ref }}
       run: |
         if [[ "${{ github.event_name }}" == "pull_request_target" ]]; then
-          echo "root_url=https://${{ github.head_ref }}--legwiki.netlify.app" >> $GITHUB_OUTPUT
+          echo "root_url=https://${HEAD_REF}--legwiki.netlify.app" >> $GITHUB_OUTPUT
           echo "is_production=false" >> $GITHUB_OUTPUT
         else
           echo "root_url=https://legwiki.lkj.io" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Potential fix for [https://github.com/legnoh/legwiki/security/code-scanning/1](https://github.com/legnoh/legwiki/security/code-scanning/1)

To fix the problem, we need to avoid directly using the user-controlled input `${{ github.head_ref }}` within the shell command. Instead, we should set this value to an intermediate environment variable and then use the environment variable within the shell script. This approach prevents potential code injection vulnerabilities.

1. Define an environment variable to hold the value of `${{ github.head_ref }}`.
2. Use the environment variable within the shell script to safely handle the input.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
