### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/legnoh/legwiki/security/code-scanning/2](https://github.com/legnoh/legwiki/security/code-scanning/2)

The best fix is to add a `permissions` block at the top level of the workflow (after the `name:` and before `on:` or after `on:`), so it applies to all jobs unless overridden. Start with least privilege necessary, i.e., `contents: read`. For jobs or steps that require additional permissions (such as deploying to Netlify with commit comments, or posting PR reviews), either the minimal set can be increased at workflow level, or (preferably) job/step-specific overrides can be added.

For this workflow, since the main actions are:
- Checkout, LFS, building: needs `contents: read`
- PR review comments (if any): may need `pull-requests: write`
- Deploy to Netlify: may want `statuses: write` if updating commit statuses, but in this config, only the deploy action uses `github-token`, and not for write actions (uses Netlify token for deploy).

Thus, a minimal block would be:
```yaml
permissions:
  contents: read
```
And, if needed, specific jobs/steps can have their own permissions blocks.

Change required:  
- Insert the `permissions: contents: read` block near the top of the file, after `name: CI`, and before `on:`.  
- No new packages/dependencies are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
