### PR TITLE
Potential fix for code scanning alert no. 12: Cache Poisoning via caching of untrusted files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ jobs:
       run: git lfs ls-files -l | cut -d' ' -f1 | sort > .lfs-assets-id
 
     - name: Restore LFS cache
+      if: github.event_name == 'push'
       uses: actions/cache@v4
       id: lfs-cache
       with:


### PR DESCRIPTION
Potential fix for [https://github.com/legnoh/legwiki/security/code-scanning/12](https://github.com/legnoh/legwiki/security/code-scanning/12)

To fix this vulnerability, we need to ensure that untrusted code can never poison cache entries available to privileged workflows. The recommended approach is:

- Do **not** use caching actions (`actions/cache`) for untrusted files in workflows triggered by `pull_request_target`—unless the cache key is guaranteed to be unique and untrusted cache is never restored in a privileged context.
- Restrict any use of `actions/cache` for LFS or similar large file artifacts to workflows triggered only on trusted events, such as `push` to trusted branches (e.g., `main`), not `pull_request_target`.
- In this YAML file, the problematic step is the `Restore LFS cache` that runs unconditionally for all events. To mitigate, run this step **only** for safe, trusted events, i.e., `push` (not PRs from forks/untrusted contributors).
- Implement this by using an `if:` conditional on the step, e.g., `if: github.event_name == 'push'`, so it doesn’t run for `pull_request_target`.
- Optionally, make it explicit that cache is never restored in the context of untrusted code.

**Required changes:**
- In .github/workflows/ci.yml, on the `Restore LFS cache` step:  
  Add an `if: github.event_name == 'push'` to restrict cache restoration to trusted `push` builds.
- No change to imports/etc. is needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
